### PR TITLE
Clarify mail group warning

### DIFF
--- a/MailInventoryValuation.php
+++ b/MailInventoryValuation.php
@@ -20,7 +20,7 @@ $Recipients = GetMailList('InventoryValuationRecipients');
 if (sizeOf($Recipients) == 0) {
 	$Title = _('Inventory Valuation') . ' - ' . _('Problem Report');
 	include('includes/header.php');
-	prnMsg(_('There are no members of the Inventory Valuation Recipients email group'), 'warn');
+	prnMsg(_('There are no members of the "InventoryValuationRecipients" email group'), 'warn');
 	include('includes/footer.php');
 	exit();
 }


### PR DESCRIPTION
The warning message when the "InventoryValuationRecipients" mail group is missing or has no members reports the "Inventory Valuation Recipients" mail group, which is confusing because the error is still reported after creating the indicated group (with spaces).

This PR changes the mail group name in the warning to "InventoryValuationRecipients" (no spaces).

There is still an issue with capitalization because creating group "InventoryValucationRecipients" actually results in "inventoryvaluationrecipients", but since capitalization appears to be ignored everything still works. 